### PR TITLE
Persist ephemeral messages on conversation close

### DIFF
--- a/crates/client/src/local_storage.rs
+++ b/crates/client/src/local_storage.rs
@@ -1,5 +1,5 @@
 use once_cell::sync::Lazy;
-use rusqlite::{Connection, params};
+use rusqlite::{params, Connection};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -244,6 +244,75 @@ pub fn append_persistent_message(
     flush_persistent()
 }
 
+/// Move any ephemeral (in-memory) messages into the persistent store.
+pub fn close_conversation() -> Result<(), String> {
+    let migrated = with_store(|store| {
+        // Capture the current set of ephemeral messages while holding the lock
+        // so we can later delete the same rows by id.
+        let entries = {
+            let ephemeral = store.ephemeral.lock().unwrap();
+            let mut stmt = ephemeral
+                .prepare(
+                    "SELECT id, from_user_id, to_user_id, body, timestamp FROM ephemeral_messages",
+                )
+                .map_err(|e| format!("prepare ephemeral fetch failed: {e}"))?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, String>(4)?,
+                    ))
+                })
+                .map_err(|e| format!("query ephemeral fetch failed: {e}"))?;
+            let mut collected = Vec::new();
+            for row in rows {
+                collected.push(row.map_err(|e| format!("row error: {e}"))?);
+            }
+            collected
+        };
+
+        if entries.is_empty() {
+            return Ok(false);
+        }
+
+        {
+            let mut persistent = store.persistent.lock().unwrap();
+            let tx = persistent
+                .transaction()
+                .map_err(|e| format!("begin persistent transaction failed: {e}"))?;
+            for (_, from_user_id, to_user_id, body, timestamp) in &entries {
+                tx.execute(
+                    "INSERT INTO messages (from_user_id, to_user_id, body, timestamp, saved) VALUES (?1, ?2, ?3, ?4, 0)",
+                    params![from_user_id, to_user_id, body, timestamp],
+                )
+                .map_err(|e| format!("insert migrated persistent message failed: {e}"))?;
+            }
+            tx.commit()
+                .map_err(|e| format!("commit persistent transaction failed: {e}"))?;
+        }
+
+        {
+            let mut ephemeral = store.ephemeral.lock().unwrap();
+            for (id, _, _, _, _) in &entries {
+                ephemeral
+                    .execute("DELETE FROM ephemeral_messages WHERE id = ?1", params![id])
+                    .map_err(|e| format!("delete migrated ephemeral failed: {e}"))?;
+            }
+        }
+
+        Ok(true)
+    })?;
+
+    if migrated {
+        flush_persistent()?;
+    }
+
+    Ok(())
+}
+
 /// Load merged history from both persistent and ephemeral stores, ordered by time.
 pub fn load_history(limit: Option<usize>) -> Result<Vec<HistoryMessage>, String> {
     let mut merged: Vec<HistoryMessage> = Vec::new();
@@ -346,7 +415,11 @@ pub fn snapshot_persistent() -> Result<(), String> {
 }
 
 /// Add or update a contact's public key by their user identity (base64 string).
-pub fn add_contact(user_id: String, pubkey: String, nickname: Option<String>) -> Result<(), String> {
+pub fn add_contact(
+    user_id: String,
+    pubkey: String,
+    nickname: Option<String>,
+) -> Result<(), String> {
     with_store(|store| {
         store
             .persistent

--- a/crates/client/tests/local_storage_conversation.rs
+++ b/crates/client/tests/local_storage_conversation.rs
@@ -1,0 +1,64 @@
+use once_cell::sync::Lazy;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+static STORAGE_GUARD: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static STORAGE_INIT: Lazy<()> = Lazy::new(|| {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.into_path();
+    std::env::set_var("RURA_CLIENT_DATA_DIR", &path);
+    rura_client::local_storage::init_storage().expect("init storage");
+});
+
+static UNIQUE_BODY: AtomicUsize = AtomicUsize::new(0);
+
+#[test]
+fn close_conversation_moves_ephemeral_into_persistent() {
+    let _guard = STORAGE_GUARD.lock().unwrap();
+    Lazy::force(&STORAGE_INIT);
+
+    rura_client::local_storage::wipe_ephemeral().expect("wipe ephemeral");
+
+    let initial_len = rura_client::local_storage::load_history(None)
+        .expect("load initial history")
+        .len();
+
+    let body_id = UNIQUE_BODY.fetch_add(1, Ordering::SeqCst);
+    let body = format!("ephemeral-to-persistent-{body_id}");
+    let timestamp = format!("2024-01-01T00:00:{body_id:02}Z");
+
+    rura_client::local_storage::append_ephemeral_message(1, 2, body.clone(), timestamp.clone())
+        .expect("append ephemeral");
+
+    rura_client::local_storage::close_conversation().expect("close conversation");
+
+    // Ephemeral cache can be wiped (e.g., on next session) without losing migrated data.
+    rura_client::local_storage::wipe_ephemeral().expect("wipe after close");
+
+    let history = rura_client::local_storage::load_history(None).expect("load history");
+    assert_eq!(
+        history.len(),
+        initial_len + 1,
+        "persistent history should grow"
+    );
+
+    let migrated = history
+        .into_iter()
+        .find(|m| m.body == body && m.from_user_id == 1 && m.to_user_id == 2)
+        .expect("migrated message present");
+
+    assert_eq!(migrated.timestamp, timestamp);
+    assert!(!migrated.saved, "migrated messages remain unsaved");
+}
+
+#[test]
+fn close_conversation_no_ephemeral_is_noop() {
+    let _guard = STORAGE_GUARD.lock().unwrap();
+    Lazy::force(&STORAGE_INIT);
+
+    // Ensure no ephemeral rows remain.
+    rura_client::local_storage::wipe_ephemeral().expect("wipe ephemeral");
+
+    // Should succeed even when there is nothing to migrate.
+    rura_client::local_storage::close_conversation().expect("close conversation noop");
+}


### PR DESCRIPTION
## Summary
- add `close_conversation` to move ephemeral messages into the persistent store and flush the encrypted snapshot
- add integration tests covering conversation shutdown persistence and the empty-queue no-op case

## Testing
- `cargo test -p rura_client` *(fails: unable to download dependencies due to restricted network access)*

------
https://chatgpt.com/codex/tasks/task_e_690b946105e8832595b6a2b40a708cfe